### PR TITLE
Update/across session creds

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const sendRequest = require('caccl-send-request');
 
 /**
  * Initializes api forwarding
- * @author Gabriel Abrams
+ * @author Gabe Abrams
  * @param {object} app - the express app to add routes to
  * @param {string} [canvasHost=canvas.instructure.com] - the Canvas host to
  *   forward requests to
@@ -39,6 +39,7 @@ module.exports = (config) => {
 
     /**
      * Attempt to send the request to Canvas
+     * @author Gabe Abrams
      * @param {boolean} [alreadyRefreshed] - if true, we have already tried to
      *   refresh the user's authorization before, so don't try that again
      */
@@ -57,6 +58,7 @@ module.exports = (config) => {
 
         /**
          * Forward the response to the client
+         * @author Gabe Abrams
          */
         const forward = () => {
           // Set status

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "caccl-api-forwarder",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "caccl-api-forwarder",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "description": "Client-side express module that forwards Canvas requests from the client to Canvas.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is part of a large across-caccl change to switch access tokens from being in the session to being in the tokenStore. This will solve token race conditions between sessions of the same user and will make it possible for users to be logged into the same app on different machines without causing issues with Canvas, though this does make it possible for users to get closer to throttling limits.